### PR TITLE
imp: Ignore files in accordance with .gitignore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,13 +1,23 @@
 [root]
 name = "cargo-count"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "ansi_term 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gitignore 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "tabwriter 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "advapi32-sys"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -48,6 +58,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "gitignore"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "glob 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempdir 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "glob"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,6 +82,16 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "advapi32-sys 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -94,6 +123,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempdir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,5 +143,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "vec_map"
 version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "winapi-build"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = "~1.5"
 glob = "~0.2"
 tabwriter = "~0.1"
 regex = "~0.1"
+gitignore = "~1"
 ansi_term = {version = "~0.7", optional = true}
 clippy    = {version = "~0.0", optional = true}
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ USAGE:
 
 FLAGS:
     -S, --follow-symlinks      Follows symlinks and counts source files it finds
+    -a, --all                  Do not ignore .gitignored paths
                                (Defaults to false when omitted)
     -h, --help                 Prints help information
         --unsafe-statistics    Displays lines and percentages of "unsafe" code

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ arg_enum! {
 #[derive(Debug)]
 pub struct Config<'a> {
     pub verbose: bool,
+    pub all: bool,
     pub thousands: Option<char>,
     pub utf8_rule: Utf8Rule,
     pub usafe: bool,
@@ -40,6 +41,7 @@ impl<'a> Config<'a> {
         }
         Ok(Config {
             verbose: m.is_present("verbose"),
+            all: m.is_present("all"),
             thousands: m.value_of("sep").map(|s| s.chars().nth(0).unwrap()),
             usafe: m.is_present("unsafe-statistics"),
             utf8_rule: value_t!(m.value_of("rule"), Utf8Rule).unwrap_or(Utf8Rule::Strict),

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@
 //! FLAGS:
 //! -S, --follow-symlinks      Follows symlinks and counts source files it
 //! finds
+//! -a, --all                  Do not ignore .gitignored paths
 //!                                (Defaults to false when omitted)
 //!     -h, --help                 Prints help information
 //! --unsafe-statistics    Displays lines and percentages of "unsafe"
@@ -184,6 +185,7 @@ extern crate ansi_term;
 extern crate tabwriter;
 extern crate glob;
 extern crate regex;
+extern crate gitignore;
 
 use std::io::Write;
 #[cfg(feature = "debug")]
@@ -227,6 +229,7 @@ fn main() {
             .author("Kevin K. <kbknapp@gmail.com>")
             .about("Displays line counts of code for cargo projects")
             .args_from_usage("-e, --exclude [paths]...    'Files or directories to exclude (automatically includes \'.git\')'
+                              -a, --all                   'Do not ignore .gitignore'd paths'
                               --unsafe-statistics         'Displays lines and percentages of \"unsafe\" code'
                               -l, --language [exts]...    'Only count these languges (by source code extension){n}\
                                                            (i.e. \'-l js py cpp\')'


### PR DESCRIPTION
I noticed discussion of this in issues #8 and #9.  Here's the approach I took: 
- By default `.gitignore`d paths are ignored.
- A `-a` / `--all` flag returns the old behavior.
- A single `.gitignore` file is looked for in the directory in which cargo count is called. No attempt is made to find additional `.gitignore` files in sub-directories.

I have a pull request open with the `gitignore` crate to reclassify `tempdir` as a dev dependency. If that patch gets merged, this patch should be able to be amended to not bring in any additional dependencies except `gitignore` itself.
