### PR TITLE
fix: Batch results by language, not file extension

### DIFF
--- a/src/count/counts.rs
+++ b/src/count/counts.rs
@@ -78,7 +78,7 @@ impl<'c> Counts<'c> {
                     let mut found = false;
                     debugln!("Searching for previous entries of that type");
                     for l in self.counts.iter_mut() {
-                        if l.lang.extension() == extension {
+                        if l.lang == pos_lang {
                             debugln!("Found");
                             found = true;
                             l.add_file(PathBuf::from(&file));

--- a/src/language.rs
+++ b/src/language.rs
@@ -2,7 +2,7 @@ use std::fmt as StdFmt;
 
 use comment::Comment;
 
-#[derive(Debug)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum Language {
     C,
     Header,
@@ -70,27 +70,6 @@ impl Language {
             Language::Toml => "TOML",
             Language::Perl => "Perl",
             Language::Go => "Go",
-        }
-    }
-
-    pub fn extension(&self) -> &str {
-        match *self {
-            Language::Cpp => "cpp",
-            Language::Hpp => "hpp",
-            Language::C => "c",
-            Language::Header => "h",
-            Language::Css => "css",
-            Language::Java => "java",
-            Language::JavaScript => "js",
-            Language::Rust => "rs",
-            Language::Xml => "xml",
-            Language::Html => "html",
-            Language::Python => "py",
-            Language::Ruby => "rb",
-            Language::Php => "php",
-            Language::Perl => "pl",
-            Language::Toml => "toml",
-            Language::Go => "go",
         }
     }
 


### PR DESCRIPTION
Fixes some extensions creating multiple entries for the same language, as reported by @byteprelude in #19.
