### PR TITLE
Fix 'eclude' typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ directory, or absolute. When '<path>' is a file, it must be relative to the curr
 directory or it will not be found. Example, if the current directory has a child 
 directory named 'target' with a child fild 'test.rs' and you use `--exclude target/test.rs' 
 
-Globs are also supported. For example, to eclude 'test.rs' files from all child directories 
+Globs are also supported. For example, to exclude 'test.rs' files from all child directories 
 of the current directory you could do '--exclude */test.rs'.
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,7 +154,7 @@
 //! directory named 'target' with a child fild 'test.rs' and you use `--exclude
 //! target/test.rs'
 //!
-//! Globs are also supported. For example, to eclude 'test.rs' files from all
+//! Globs are also supported. For example, to exclude 'test.rs' files from all
 //! child directories
 //! of the current directory you could do '--exclude */test.rs'.
 //! ```
@@ -249,7 +249,7 @@ absolute. When '--exclude <PATH>' is a file or path, it must be relative to the 
 or it will not be found. Example, if the current directory has a child directory named 'target' \
 with a child fild 'test.rs' and you use `--exclude target/test.rs'
 \n\
-Globs are also supported. For example, to eclude 'test.rs' files from all child directories of \
+Globs are also supported. For example, to exclude 'test.rs' files from all child directories of \
 the current directory you could do '--exclude */test.rs'."))
         .get_matches();
 


### PR DESCRIPTION
Just noticed this typo and thought I'd fix it :-)