### PR TITLE
Fixed the unsafe regex.

### DIFF
--- a/src/count/counts.rs
+++ b/src/count/counts.rs
@@ -105,7 +105,7 @@ impl<'c> Counts<'c> {
         for count in self.counts.iter_mut() {
             debugln!("iter; count={:?};", count);
             let re = if let Some(kw) = count.lang.unsafe_keyword() {
-                Regex::new(&*format!("(.*?)([:^word:]{}[:^word:])(.*)", kw)).unwrap()
+                Regex::new(&*format!("(.*)(\\b{}\\b)(.*)", kw)).unwrap()
             } else {
                 Regex::new("").unwrap()
             };


### PR DESCRIPTION
The previous regex missed many occurrences of unsafe, because it required something before and behind the keyword (see #38). Requiring a word boundary fixes that problem.

However, the counting of unsafe code is still fishy. For example, occurrences of "unsafe" in strings are counted as unsafe code. Also, the formatting matters. This counts as 3 unsafe lines:
``` rust
unsafe {
  func();
}
```
And this as 1 unsafe line:
``` rust
unsafe
{
  func();
}
```